### PR TITLE
Read MGF and task-level inputs

### DIFF
--- a/tools/peptide_statistics_hpp/cosine_to_synthetics.py
+++ b/tools/peptide_statistics_hpp/cosine_to_synthetics.py
@@ -89,7 +89,7 @@ def read_mgf_spectrum(spectrum):
         peaks,
         precursor,
         None,
-        spectrum['params']['title'],
+        "scan={}".format(spectrum['params']['scans']),
         None
     )
 
@@ -242,6 +242,8 @@ def main():
         elif 'f.' in filename:
             # checking uploads directory
             filepath = filename.replace('f.','/data/ccms-data/uploads/')
+            if not Path(filepath).exists():
+                filepath = filename.replace('f.','/data/ccms-data/tasks/')
         else:
             filepath = filename
 


### PR DESCRIPTION
Add a (long awaited) feature to read MGF
1. Setup MGF reader
2. Add reading from task outputs (i.e. library representatives)
3. TODO: Update to output task-"USIs"