### PR TITLE
Add symlinks on ccms for dependencies

### DIFF
--- a/tools/peptide_statistics_hpp/nextprot_releases
+++ b/tools/peptide_statistics_hpp/nextprot_releases
@@ -1,0 +1,1 @@
+/Users/bpullman/nextprot_releases

--- a/tools/peptide_statistics_hpp/python_ms_utilities
+++ b/tools/peptide_statistics_hpp/python_ms_utilities
@@ -1,0 +1,1 @@
+/data/beta-proteomics2/tools/python_ms_utilities/1.0.8/src


### PR DESCRIPTION
I think this is the best practice, then we can version control the python_ms_utilities version, even though its clunky