### PR TITLE
Output MassIVE-search compliant Intermediate Mappings

### DIFF
--- a/peptide_statistics_hpp/binding.xml
+++ b/peptide_statistics_hpp/binding.xml
@@ -65,9 +65,10 @@
     <bind action="map_peptides" tool="map_peptides">
         <inputAsRequirement port="peptide_list"             requirement="peptide_list"/>
         <inputAsRequirement port="fastadb"                  requirement="fastadb"/>
-        <inputAsRequirement port="con_fastadb"                  requirement="con_fastadb"/>
+        <inputAsRequirement port="con_fastadb"              requirement="con_fastadb"/>
         <inputAsRequirement port="exon_fasta"               requirement="exon_fasta"/>
-		    <productionToOutput port="peptide_coverage"         production="peptide_coverage"/>
+		<productionToOutput port="peptide_coverage"         production="peptide_coverage"/>
+        <productionToOutput port="peptide_coverage_exact"   production="peptide_coverage_exact"/>
     </bind>
 
     <bind action="demangle_spec_on_server" tool="demangle_spec_on_server">
@@ -137,6 +138,9 @@
         <compression type="zip"/>
         <upload port="unique_peptides_list" type="file">
             <query name="resource" value="unique_peptides_list"/>
+        </upload>
+        <upload port="peptide_coverage_exact" type="folder">
+            <query name="resource" value="peptide_coverage_exact"/>
         </upload>
         <upload port="protein_coverage" type="file">
             <query name="resource" value="protein_coverage"/>

--- a/peptide_statistics_hpp/flow.xml
+++ b/peptide_statistics_hpp/flow.xml
@@ -25,6 +25,8 @@
 	<collection name="peptide_coverage_comparisons"/>
 
     <object name="protein_coverage"/>
+	<collection name="peptide_coverage_exact"/>
+
 		<object name="novel_psms"/>
 		<object name="novel_peptides"/>
     <object name="unique_peptides_list"/>
@@ -77,6 +79,8 @@
 			<input  port="con_fastadb"             	    collection="con_fastadb"/>
 							<input  port="exon_fasta"             	object="exon_fasta"/>
         <output port="peptide_coverage"       	collection="peptide_coverage"/>
+		        <output port="peptide_coverage_exact"       	collection="peptide_coverage_exact"/>
+
     </action>
 
     <collection name="spec_on_server_demangled"/>
@@ -165,6 +169,7 @@
 
     <action name="end">
         <input port="unique_peptides_list"       object="unique_peptides_list"/>
+		<input port="peptide_coverage_exact"       	collection="peptide_coverage_exact"/>
         <input port="protein_coverage" object="protein_coverage"/>
 		<input port="library_coverage_summary_statistics" object="library_coverage_summary_statistics"/>
 		<input port="debug_protein_coverage" collection="debug_protein_coverage"/>

--- a/peptide_statistics_hpp/input.xml
+++ b/peptide_statistics_hpp/input.xml
@@ -191,6 +191,15 @@
 			<validator type="set" />
 		</parameter>
 
+		<parameter name="only_mapping" label="Only output mapping">
+			<options>
+				<option label="Yes" value="1" />
+				<option label="No" value="0" />
+			</options>
+			<default value="0" />
+			<validator type="set" />
+		</parameter>
+
 		<parameter name="library_name" label="Library Name">
 			<options>
 				<option label="MassIVE-KB (combined)" value="1" />
@@ -627,5 +636,17 @@
 						<input type="select" parameter="hpp_aggregation_function"/>
 					</cell>
 				</row>
+	</block>
+	<block label="Advanced Mapping Outputs">
+		<row>
+			<cell>
+				<label>
+					<content parameter="only_mapping"/>
+				</label>
+			</cell>
+			<cell colspan="2">
+				<input type="select" parameter="only_mapping"/>
+			</cell>
+		</row>
 	</block>
 </interface>

--- a/peptide_statistics_hpp/tool.xml
+++ b/peptide_statistics_hpp/tool.xml
@@ -90,6 +90,7 @@
       <require name="con_fastadb"            type="folder"/>
       <require name="exon_fasta"            type="file"/>
       <produce name="peptide_coverage"        type="folder"/>
+      <produce name="peptide_coverage_exact"        type="folder"/>
       <execution env="binary" argConvention="adhoc">
           <arg pathRef="map_peptides.script"/>
           <arg option="-proteome_fasta"          valueRef="fastadb"/>
@@ -97,6 +98,7 @@
           <arg option="-exon_fasta"          valueRef="exon_fasta"/>
           <arg option="-peptide_list"   valueRef="peptide_list"/>
           <arg option="-output_folder"  valueRef="peptide_coverage"/>
+          <arg option="-output_folder_exact"  valueRef="peptide_coverage_exact"/>
         </execution>
   </tool>
 

--- a/peptide_statistics_hpp/tool.xml
+++ b/peptide_statistics_hpp/tool.xml
@@ -200,6 +200,7 @@
           <arg option="-explorers_output"     valueRef="explorer_export"/>
           <arg option="-variant_output"     valueRef="@use_variants"/>
           <arg option="-hpp_protein_score_aggregation" valueRef="@hpp_aggregation_function"/>
+          <arg option="-skip"               valueRef="@only_mapping"/>
       </execution>
   </tool>
   

--- a/tools/peptide_statistics_hpp/generate_summary.py
+++ b/tools/peptide_statistics_hpp/generate_summary.py
@@ -111,6 +111,13 @@ def prepare_pandas_table(input_file):
 
 def main():
     args = arguments()
+    if args.input_file.stat().st_size != 0:
+        cond_main(args)
+    else:
+        args.output_file.touch()
+
+def cond_main(args):
+    args = arguments()
 
     headers = {}
 

--- a/tools/peptide_statistics_hpp/map_peptides.py
+++ b/tools/peptide_statistics_hpp/map_peptides.py
@@ -13,6 +13,7 @@ def arguments():
     parser.add_argument('-e','--exon_fasta', type = Path, help='Input FASTA Exon Mapping Database')
     parser.add_argument('-p','--peptide_list', type = Path, help='Peptide List')
     parser.add_argument('-o','--output_folder', type = Path, help='Output Folder')
+    parser.add_argument('-x','--output_folder_exact', type = Path, help='Output Folder For Exact Matches')
 
     if len(sys.argv) < 3:
         parser.print_help()
@@ -63,6 +64,26 @@ def main():
             output_dict["mapped_exons"] = mapping.exon_mappings_to_string(mapped_exons)
 
             w.writerow(output_dict)
+
+    with open(args.output_folder_exact.joinpath(args.peptide_list.name), 'w') as f:
+        w = DictWriter(f, delimiter = '\t', fieldnames = ['peptide','protein'])
+        w.writeheader()
+
+        for peptide in peptide_list:
+
+            output_dict = {}
+
+            mapped_proteins = mapping.map_peptide_to_proteome(peptide,proteome_with_decoys,kmer_proteome_hashes)
+            for mapped_protein in mapped_proteins:
+                if not mapped_protein.mismatches:
+                    protein = proteome_with_decoys.proteins[mapped_protein.protein_accession]
+                    if not protein.decoy:
+                        output_dict = {}
+
+                        output_dict["peptide"] = peptide
+                        output_dict["protein"] = mapping.protein_to_full_uniprot_string(protein)
+
+                        w.writerow(output_dict)
 
 if __name__ == "__main__":
     main()

--- a/tools/peptide_statistics_hpp/map_peptides.py
+++ b/tools/peptide_statistics_hpp/map_peptides.py
@@ -77,13 +77,12 @@ def main():
             for mapped_protein in mapped_proteins:
                 if not mapped_protein.mismatches:
                     protein = proteome_with_decoys.proteins[mapped_protein.protein_accession]
-                    if not protein.decoy:
-                        output_dict = {}
+                    output_dict = {}
 
-                        output_dict["peptide"] = peptide
-                        output_dict["protein"] = mapping.protein_to_full_uniprot_string(protein)
+                    output_dict["peptide"] = peptide
+                    output_dict["protein"] = mapping.protein_to_full_uniprot_string(protein)
 
-                        w.writerow(output_dict)
+                    w.writerow(output_dict)
 
 if __name__ == "__main__":
     main()

--- a/tools/peptide_statistics_hpp/peptide_protein_cosine.py
+++ b/tools/peptide_statistics_hpp/peptide_protein_cosine.py
@@ -72,6 +72,8 @@ theoretical_mass = lambda xs: sum([aa_dict[x] for x in xs]) + 18.010564686
 
 no_mod_il = lambda pep: ''.join([p.replace('I','L') for p in pep if p.isalpha()])
 
+handle_x_aa = lambda seq, mass: 'N/A' if re.search('[BXZ]',seq) else mass()
+
 def seq_theoretical_mass(sequence):
     aa = ''.join([a for a in sequence if a.isalpha()])
     mods = ''.join([m for m in sequence if not m.isalpha()])
@@ -79,7 +81,7 @@ def seq_theoretical_mass(sequence):
         mods = eval(mods)
     else:
         mods = 0
-    return (theoretical_mass(aa) + mods + 1.007276035)
+    return handle_x_aa(aa,lambda: theoretical_mass(aa) + mods + 1.007276035)
 
 
 def theoretical_mz(sequence,charge):
@@ -89,7 +91,7 @@ def theoretical_mz(sequence,charge):
         mods = eval(mods)
     else:
         mods = 0
-    return (theoretical_mass(aa) + mods + (int(charge)*1.007276035))/int(charge)
+    return handle_x_aa(aa,lambda: (theoretical_mass(aa) + mods + (int(charge)*1.007276035))/int(charge))
 
 def integer_mod_mass(sequence):
     mods = ''.join([m for m in sequence if not m.isalpha()])

--- a/tools/peptide_statistics_hpp/peptide_protein_cosine.py
+++ b/tools/peptide_statistics_hpp/peptide_protein_cosine.py
@@ -54,6 +54,7 @@ def arguments():
     parser.add_argument('--explorers_output', type = Path, help='Tables for Explorers')
     parser.add_argument('--variant_output', type = int, help='Variant level outputs',default=0)
     parser.add_argument('--hpp_protein_score_aggregation', type = str, help='HPP Protein Aggregation (max or sum')
+    parser.add_argument('--skip', type = int, help='Skip this node')
 
     if len(sys.argv) < 4:
         parser.print_help()
@@ -183,7 +184,20 @@ def find_overlap(existing_peptides, new_peptides, protein_length, protein_pe, na
 
 def main():
     args = arguments()
+    if not args.skip:
+        cond_main(args)
+    else:
+        args.output_psms.touch()
+        args.output_peptides.touch()
+        args.output_proteins.touch()
+        args.output_exons.touch()
+        args.output_mappings.touch()
+        args.output_dataset_proteins_hpp.touch()
+        args.output_dataset_proteins_all.touch()
+        args.output_task_proteins_hpp.touch()
+        args.output_task_proteins_all.touch()
 
+def cond_main(args):
     hpp_score_aggregation = lambda xs: max(xs)
 
     representative_per_precursor = {}


### PR DESCRIPTION
Add the ability to skip most HPP-Inspector features and just output a mapping.